### PR TITLE
Change return value of controllers

### DIFF
--- a/relations/controllers.py
+++ b/relations/controllers.py
@@ -30,32 +30,6 @@ def service_status(params: MultiDict) -> Response:
     return {'iam': 'ok'}, HTTPStatus.OK, {}
 
 
-def relation2dict(rel: Relation) -> Dict[str, Any]:
-    """Convert a relation object to a dict."""
-    # dict of an e-print
-    dic_e_print: Dict[str, Any] = {}
-    dic_e_print['arxiv_id'] = str(rel.e_print.arxiv_id)
-    dic_e_print['version'] = rel.e_print.version
-
-    # dict of a resource
-    dic_resource: Dict[str, Any] = {}
-    dic_resource['type'] = rel.resource.resource_type
-    dic_resource['id'] = rel.resource.identifier
-
-    # dict of a relation
-    dic: Dict[str, Any] = {}
-    dic['id'] = str(rel.identifier)
-    dic['relation_type'] = support_json_default(rel.relation_type)
-    dic['e_print'] = dic_e_print
-    dic['resource'] = dic_resource
-    dic['added_at'] = support_json_default(rel.added_at)
-    dic['description'] = rel.description
-    dic['creator'] = rel.creator
-    dic['supercedes_or_suppresses'] = rel.supercedes_or_suppresses
-
-    return dic
-
-
 def create_new(arxiv_id_str: str,
                arxiv_ver: int,
                payload: Dict[str, Any]) -> Response:
@@ -96,7 +70,7 @@ def create_new(arxiv_id_str: str,
                                payload.get('creator'))
 
         # create the result value
-        result: Dict[str, Any] = relation2dict(rel)
+        result: Dict[str, Any] = rel._asdict()
 
         # return
         return result, HTTPStatus.OK, {}
@@ -155,7 +129,7 @@ def supercede(arxiv_id_str: str,
                                    payload.get('creator'))
 
         # create the result value
-        result: Dict[str, Any] = relation2dict(new_rel)
+        result: Dict[str, Any] = new_rel._asdict()
 
         # return
         return result, HTTPStatus.OK, {}
@@ -218,7 +192,7 @@ def suppress(arxiv_id_str: str,
                                    payload.get('creator'))
 
         # create the result value
-        result: Dict[str, Any] = relation2dict(new_rel)
+        result: Dict[str, Any] = new_rel._asdict()
 
         # return
         return result, HTTPStatus.OK, {}

--- a/relations/controllers.py
+++ b/relations/controllers.py
@@ -10,7 +10,6 @@ can split this into ``controllers/api.py`` and ``controllers/ui.py``.
 
 from typing import Tuple, Any, Dict, List
 from http import HTTPStatus
-import json
 
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import InternalServerError
@@ -33,15 +32,23 @@ def service_status(params: MultiDict) -> Response:
 
 def relation2dict(rel: Relation) -> Dict[str, Any]:
     """Convert a relation object to a dict."""
-    dic: Dict[str, Any] = {}
+    # dict of an e-print
+    dic_e_print: Dict[str, Any] = {}
+    dic_e_print['arxiv_id'] = str(rel.e_print.arxiv_id)
+    dic_e_print['version'] = rel.e_print.version
 
+    # dict of a resource
+    dic_resource: Dict[str, Any] = {}
+    dic_resource['type'] = rel.resource.resource_type
+    dic_resource['id'] = rel.resource.identifier
+
+    # dict of a relation
+    dic: Dict[str, Any] = {}
     dic['id'] = str(rel.identifier)
     dic['relation_type'] = support_json_default(rel.relation_type)
-    dic['arxiv_id'] = rel.e_print.arxiv_id
-    dic['arxiv_ver'] = rel.e_print.version
-    dic['resource_type'] = rel.resource.resource_type
-    dic['resource_id'] = rel.resource.identifier
-    dic['added_at'] = rel.added_at
+    dic['e_print'] = dic_e_print
+    dic['resource'] = dic_resource
+    dic['added_at'] = support_json_default(rel.added_at)
     dic['description'] = rel.description
     dic['creator'] = rel.creator
     dic['supercedes_or_suppresses'] = rel.supercedes_or_suppresses

--- a/relations/test_controllers.py
+++ b/relations/test_controllers.py
@@ -5,8 +5,7 @@ from unittest import TestCase, mock
 from datetime import datetime
 from typing import Any
 from werkzeug.exceptions import InternalServerError
-from relations.controllers import create_new, supercede, suppress, \
-    relation2dict
+from relations.controllers import create_new, supercede, suppress
 from relations.domain import Relation, RelationType, EPrint, Resource, \
     support_json_default
 from relations.services.create import StorageError
@@ -41,7 +40,7 @@ class TestRelationController(TestCase):
         res1, status, res2 = create_new(rel.e_print.arxiv_id,
                                         rel.e_print.version,
                                         payload)
-        self.assertDictEqual(res1, relation2dict(rel))
+        self.assertDictEqual(res1, rel._asdict())
         self.assertEqual(status, HTTPStatus.OK)
         self.assertDictEqual(res2, {})
 
@@ -139,7 +138,7 @@ class TestRelationController(TestCase):
                                        new_rel.e_print.version,
                                        prev_rel.identifier,
                                        payload)
-        self.assertDictEqual(res1, relation2dict(new_rel))
+        self.assertDictEqual(res1, new_rel._asdict())
         self.assertEqual(status, HTTPStatus.OK)
         self.assertDictEqual(res2, {})
 
@@ -305,7 +304,7 @@ class TestRelationController(TestCase):
                                       new_rel.e_print.version,
                                       prev_rel.identifier,
                                       payload)
-        self.assertDictEqual(res1, relation2dict(new_rel))
+        self.assertDictEqual(res1, new_rel._asdict())
         self.assertEqual(status, HTTPStatus.OK)
         self.assertDictEqual(res2, {})
 

--- a/relations/test_controllers.py
+++ b/relations/test_controllers.py
@@ -5,7 +5,8 @@ from unittest import TestCase, mock
 from datetime import datetime
 from typing import Any
 from werkzeug.exceptions import InternalServerError
-from relations.controllers import create_new, supercede, suppress
+from relations.controllers import create_new, supercede, suppress, \
+    relation2dict
 from relations.domain import Relation, RelationType, EPrint, Resource, \
     support_json_default
 from relations.services.create import StorageError
@@ -40,9 +41,7 @@ class TestRelationController(TestCase):
         res1, status, res2 = create_new(rel.e_print.arxiv_id,
                                         rel.e_print.version,
                                         payload)
-        self.assertDictEqual(res1,
-                             {rel.identifier: 
-                              json.dumps(rel, default=support_json_default)})
+        self.assertDictEqual(res1, relation2dict(rel))
         self.assertEqual(status, HTTPStatus.OK)
         self.assertDictEqual(res2, {})
 
@@ -140,11 +139,9 @@ class TestRelationController(TestCase):
                                        new_rel.e_print.version,
                                        prev_rel.identifier,
                                        payload)
-        self.assertDictEqual(res1,
-                             {new_rel.identifier: 
-                              json.dumps(new_rel, default=support_json_default)})
+        self.assertDictEqual(res1, relation2dict(new_rel))
         self.assertEqual(status, HTTPStatus.OK)
-        self.assertDictEqual(res2, {"previous": prev_rel.identifier})
+        self.assertDictEqual(res2, {})
 
     @mock.patch('relations.controllers.from_id')
     @mock.patch('relations.controllers.create')
@@ -308,11 +305,9 @@ class TestRelationController(TestCase):
                                       new_rel.e_print.version,
                                       prev_rel.identifier,
                                       payload)
-        self.assertDictEqual(res1,
-                             {new_rel.identifier: 
-                              json.dumps(new_rel, default=support_json_default)})
+        self.assertDictEqual(res1, relation2dict(new_rel))
         self.assertEqual(status, HTTPStatus.OK)
-        self.assertDictEqual(res2, {"previous": prev_rel.identifier})
+        self.assertDictEqual(res2, {})
 
     @mock.patch('relations.controllers.from_id')
     @mock.patch('relations.controllers.create')


### PR DESCRIPTION
This PR changes the return values of `controllers` and let them quit serialization inside but make a dict that represents a relation. This enables the `routes` only serialize the returned values.