### PR TITLE
Use request.json in routes

### DIFF
--- a/relations/routes/api.py
+++ b/relations/routes/api.py
@@ -25,7 +25,9 @@ def service_status() -> Response:
 @blueprint.route('/<string:arxiv_id_str>v<int:arxiv_ver>/relations', methods=['POST'])
 def create_new(arxiv_id_str: str, arxiv_ver: int) -> Response:
     """Create a new relation for an e-print."""
-    response_data, status_code, headers = controllers.create_new(arxiv_id_str, arxiv_ver, request.data)
+    response_data, status_code, headers = controllers.create_new(arxiv_id_str,
+                                                                 arxiv_ver,
+                                                                 request.json)
     response: Response = jsonify(response_data)
     response.status_code = status_code
     response.headers.extend(headers)
@@ -34,7 +36,10 @@ def create_new(arxiv_id_str: str, arxiv_ver: int) -> Response:
 @blueprint.route('/<string:arxiv_id_str>v<int:arxiv_ver>/relations/<string:relation_id_str>', methods=['PUT'])
 def supercede(arxiv_id_str: str, arxiv_ver: int, relation_id_str: str) -> Response:
     """Create a new relation for an e-print which supersedes an existing relation."""
-    response_data, status_code, headers = controllers.supercede(arxiv_id_str, arxiv_ver, relation_id_str, request.data)
+    response_data, status_code, headers = controllers.supercede(arxiv_id_str,
+                                                                arxiv_ver,
+                                                                relation_id_str,
+                                                                request.json)
     response: Response = jsonify(response_data)
     response.status_code = status_code
     response.headers.extend(headers)
@@ -43,7 +48,10 @@ def supercede(arxiv_id_str: str, arxiv_ver: int, relation_id_str: str) -> Respon
 @blueprint.route('/<string:arxiv_id_str>v<int:arxiv_ver>/relations/<string:relation_id_str>', methods=['DELETE'])
 def suppress(arxiv_id_str: str, arxiv_ver: int, relation_id_str: str) -> Response:
     """Create a new relation for an e-print which supresses an existing relation."""
-    response_data, status_code, headers = controllers.suppress(arxiv_id_str, arxiv_ver, relation_id_str, request.data)
+    response_data, status_code, headers = controllers.suppress(arxiv_id_str,
+                                                               arxiv_ver,
+                                                               relation_id_str,
+                                                               request.json)
     response: Response = jsonify(response_data)
     response.status_code = status_code
     response.headers.extend(headers)

--- a/relations/routes/tests/__init__.py
+++ b/relations/routes/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for ui and api routes"""
+"""Tests for ui and api routes."""


### PR DESCRIPTION
Current develop branch has type mismatches. `routes` passes `request.data` to `controllers.create_new()` and similar functions, but these functions expects to receive JSON data.
So this PR changes the arguments and passes `request.json` instead.
