### PR TITLE
Fixes for type checking and doc-style review in CI

### DIFF
--- a/relations/routes/tests/__init__.py
+++ b/relations/routes/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for ui and api routes"""
+"""Tests for ui and api routes."""

--- a/tests/style.sh
+++ b/tests/style.sh
@@ -8,9 +8,11 @@ pipenv run pydocstyle --convention=numpy --add-ignore=D401 ${PROJECT}
 PYDOCSTYLE_STATUS=$?
 if [ $PYDOCSTYLE_STATUS -ne 0 ]; then PYDOCSTYLE_STATE="failure" && echo "pydocstyle failed"; else PYDOCSTYLE_STATE="success" &&  echo "pydocstyle passed"; fi
 
+if [ "$TRAVIS_PULL_REQUEST_SHA" = "" ];  then SHA=$TRAVIS_COMMIT; else SHA=$TRAVIS_PULL_REQUEST_SHA; fi
+
 if [ -z ${GITHUB_TOKEN} ]; then
     echo "Github token not set; will not report results";
-else 
+else
     curl -u $USERNAME:$GITHUB_TOKEN \
         -d '{"state": "'$PYDOCSTYLE_STATE'", "target_url": "https://travis-ci.org/'$TRAVIS_REPO_SLUG'/builds/'$TRAVIS_BUILD_ID'", "description": "", "context": "code-quality/pydocstyle"}' \
         -XPOST https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/$SHA \

--- a/tests/type-check.sh
+++ b/tests/type-check.sh
@@ -7,9 +7,11 @@ PROJECT=$1
 MYPY_STATUS=$( pipenv run mypy -p ${PROJECT} | tee /dev/tty | grep -v "test.*" | wc -l | tr -d '[:space:]' )
 if [ $MYPY_STATUS -ne 0 ]; then MYPY_STATE="failure" && echo "mypy failed"; else MYPY_STATE="success" &&  echo "mypy passed"; fi
 
+if [ "$TRAVIS_PULL_REQUEST_SHA" = "" ];  then SHA=$TRAVIS_COMMIT; else SHA=$TRAVIS_PULL_REQUEST_SHA; fi
+
 if [ -z ${GITHUB_TOKEN} ]; then
     echo "Github token not set; will not report results";
-else 
+else
     curl -u $USERNAME:$GITHUB_TOKEN \
         -d '{"state": "'$MYPY_STATE'", "target_url": "https://travis-ci.org/'$TRAVIS_REPO_SLUG'/builds/'$TRAVIS_BUILD_ID'", "description": "", "context": "code-quality/mypy"}' \
         -XPOST https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/$SHA \


### PR DESCRIPTION
Travis was not sending the results for mypy and pydocstyle back to Github. We were missing a line in each of those scripts that set the hash for the commit/PR for the HTTP request containing the results, so I added them back.

There was one error from pydocstyle, which I fixed in this PR.

The errors from mypy are fixed by #29, so we can ignore them for now.